### PR TITLE
feat: scaffold QSAR template with baseline pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+artifacts/
+*.pyc
+*.pkl
+*.joblib
+run_*/
+*.log
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# RonqSAR QSAR Template
+
+A minimal, local-first QSAR template integrating RDKit and a local Ollama LLM advisor.
+
+## Quickstart
+
+```bash
+pip install -r requirements.txt  # optional
+python -m qsar.cli fit --config configs/esol.yaml
+uvicorn qsar.serve.api:app --reload
+```
+
+The demo trains a LightGBM regressor on a small ESOL-like dataset using a scaffold split and generates a report under `artifacts/`.
+
+## CLI
+
+- `qsar fit --config configs/esol.yaml`
+- `qsar predict --model artifacts/best_model.joblib --input new.csv --out preds.csv`
+
+## Tests
+
+Run unit tests with `pytest -q`.

--- a/advisor/ollama_client.py
+++ b/advisor/ollama_client.py
@@ -1,0 +1,18 @@
+"""Client for local Ollama server."""
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+import requests
+
+OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434/api/generate")
+MODEL_NAME = os.getenv("OLLAMA_MODEL", "biomistral:7b-instruct")
+
+
+def generate(prompt: str, system: str = "") -> str:
+    payload = {"model": MODEL_NAME, "prompt": prompt, "system": system}
+    r = requests.post(OLLAMA_URL, json=payload, timeout=30)
+    r.raise_for_status()
+    data = r.json()
+    return data.get("response", "")

--- a/advisor/sessions.py
+++ b/advisor/sessions.py
@@ -1,0 +1,41 @@
+"""Advisor sessions for querying Ollama LLM."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict
+
+from .ollama_client import generate
+
+SYS_PROMPT = Path(__file__).with_name("system_prompt.txt").read_text()
+
+
+def propose_smarts_filters(sample_smiles: List[str]) -> List[str]:
+    prompt = (
+        "Given the following SMILES list, suggest a few SMARTS patterns to filter common bad actors. "
+        "Return a bullet list of SMARTS strings.\n" + "\n".join(sample_smiles)
+    )
+    text = generate(prompt, system=SYS_PROMPT)
+    lines = [line.strip("-* \n") for line in text.splitlines() if line.strip()]
+    return [l for l in lines if l]
+
+
+def suggest_hparam_space(model_name: str) -> Dict[str, str]:
+    prompt = f"Suggest Optuna hyperparameter search space for {model_name}. Return YAML mapping."
+    text = generate(prompt, system=SYS_PROMPT)
+    try:
+        import yaml
+
+        data = yaml.safe_load(text)
+        if isinstance(data, dict):
+            return {k: str(v) for k, v in data.items()}
+    except Exception:
+        pass
+    return {"raw": text}
+
+
+def explain_outliers(smiles_list: List[str], y_true: List[float], y_pred: List[float]) -> str:
+    prompt = (
+        "Explain possible reasons for the following prediction outliers in QSAR."\
+        "\nSMILES, true, pred\n" + "\n".join(f"{s},{t},{p}" for s, t, p in zip(smiles_list, y_true, y_pred))
+    )
+    return generate(prompt, system=SYS_PROMPT)

--- a/advisor/system_prompt.txt
+++ b/advisor/system_prompt.txt
@@ -1,0 +1,1 @@
+You are a helpful cheminformatics advisor. Provide suggestions or explanations only. Do not output executable code.

--- a/configs/esol.yaml
+++ b/configs/esol.yaml
@@ -1,0 +1,11 @@
+data: data/esol.csv
+target: y
+model: lightgbm
+features:
+  ecfp4: 2048
+split: scaffold
+test_size: 0.2
+seed: 0
+n_trials: 1
+output: artifacts
+alpha: 0.1

--- a/configs/lightgbm.yaml
+++ b/configs/lightgbm.yaml
@@ -1,0 +1,2 @@
+model: lightgbm
+n_trials: 10

--- a/data/esol.csv
+++ b/data/esol.csv
@@ -1,0 +1,11 @@
+smiles,y
+CCO,1.0
+CCN,1.2
+CCC,0.5
+c1ccccc1,0.1
+CC(=O)O,0.8
+CCOCC,1.3
+c1ccncc1,0.2
+CCOC(=O)C,0.9
+CCSC,0.7
+CC(O)C,1.1

--- a/filters/smarts.yaml
+++ b/filters/smarts.yaml
@@ -1,0 +1,1 @@
+suggestions: []

--- a/qsar/__init__.py
+++ b/qsar/__init__.py
@@ -1,0 +1,3 @@
+"""RonqSAR QSAR template."""
+__all__ = []
+__version__ = "0.1.0"

--- a/qsar/chem/featurize.py
+++ b/qsar/chem/featurize.py
@@ -1,0 +1,58 @@
+"""Molecular featurization utilities."""
+from __future__ import annotations
+
+from typing import Iterable, List, Tuple
+
+import numpy as np
+from rdkit import Chem
+from rdkit.Chem import AllChem, MACCSkeys
+from sklearn.preprocessing import RobustScaler
+
+try:
+    from mordred import Calculator, descriptors
+except Exception:  # pragma: no cover - mordred optional
+    Calculator = None
+    descriptors = None
+
+
+def morgan_fingerprint(smiles: List[str], radius: int = 2, n_bits: int = 2048) -> np.ndarray:
+    """Compute Morgan/ECFP fingerprints."""
+    fps = []
+    for smi in smiles:
+        mol = Chem.MolFromSmiles(smi)
+        if mol is None:
+            fps.append(np.zeros(n_bits, dtype=int))
+            continue
+        fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=n_bits)
+        arr = np.zeros((n_bits,), dtype=int)
+        AllChem.DataStructs.ConvertToNumpyArray(fp, arr)
+        fps.append(arr)
+    return np.asarray(fps)
+
+
+def maccs_keys(smiles: List[str]) -> np.ndarray:
+    """Compute MACCS keys."""
+    fps = []
+    for smi in smiles:
+        mol = Chem.MolFromSmiles(smi)
+        if mol is None:
+            fps.append(np.zeros(167, dtype=int))
+            continue
+        fp = MACCSkeys.GenMACCSKeys(mol)
+        arr = np.zeros((167,), dtype=int)
+        AllChem.DataStructs.ConvertToNumpyArray(fp, arr)
+        fps.append(arr[1:])  # drop first bit per RDKit docs
+    return np.asarray(fps)
+
+
+def mordred_descriptors(smiles: List[str]) -> Tuple[np.ndarray, List[str]]:
+    """Compute Mordred descriptors with robust scaling."""
+    if Calculator is None:
+        raise ImportError("mordred package is required for descriptors")
+    mols = [Chem.MolFromSmiles(smi) for smi in smiles]
+    calc = Calculator(descriptors, ignore_3D=True)
+    df = calc.pandas(mols)
+    df = df.replace([np.inf, -np.inf], np.nan).dropna(axis=1, how="any")
+    scaler = RobustScaler().fit(df.values)
+    arr = scaler.transform(df.values)
+    return arr.astype(float), list(df.columns)

--- a/qsar/chem/scaffold.py
+++ b/qsar/chem/scaffold.py
@@ -1,0 +1,51 @@
+"""Scaffold utilities including Bemis-Murcko scaffold split."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple
+
+import numpy as np
+from rdkit import Chem
+from rdkit.Chem.Scaffolds import MurckoScaffold
+
+
+@dataclass
+class SplitIndices:
+    train: np.ndarray
+    test: np.ndarray
+
+
+def bemis_murcko_scaffold(smiles: str) -> str:
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        return ""
+    core = MurckoScaffold.GetScaffoldForMol(mol)
+    return Chem.MolToSmiles(core)
+
+
+def scaffold_split(smiles: Sequence[str], test_size: float = 0.2, seed: int = 0) -> SplitIndices:
+    """Split dataset by scaffolds."""
+    scaffolds = {}
+    for idx, smi in enumerate(smiles):
+        scaf = bemis_murcko_scaffold(smi)
+        scaffolds.setdefault(scaf, []).append(idx)
+    rng = np.random.default_rng(seed)
+    scaffold_keys = list(scaffolds.keys())
+    rng.shuffle(scaffold_keys)
+    n_total = len(smiles)
+    n_test = int(n_total * test_size)
+    test_indices = []
+    for scaf in scaffold_keys:
+        if len(test_indices) >= n_test:
+            break
+        test_indices.extend(scaffolds[scaf])
+    train_indices = [i for i in range(n_total) if i not in test_indices]
+    return SplitIndices(train=np.array(train_indices), test=np.array(test_indices))
+
+
+def random_split(n: int, test_size: float = 0.2, seed: int = 0) -> SplitIndices:
+    rng = np.random.default_rng(seed)
+    idx = np.arange(n)
+    rng.shuffle(idx)
+    n_test = int(n * test_size)
+    return SplitIndices(train=idx[n_test:], test=idx[:n_test])

--- a/qsar/chem/standardize.py
+++ b/qsar/chem/standardize.py
@@ -1,0 +1,67 @@
+"""Molecule standardization utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Tuple
+
+from rdkit import Chem
+from rdkit.Chem import rdMolStandardize
+
+
+@dataclass
+class StandardizationResult:
+    """Holds standardized molecules and statistics."""
+    smiles: List[str]
+    valid_idx: List[int]
+    failed: List[str]
+
+
+def standardize_smiles(smiles: str) -> str | None:
+    """Standardize a SMILES string.
+
+    Steps:
+    - Parse SMILES and sanitize
+    - Remove salts and small fragments
+    - Uncharge / reionize
+    - Return canonical SMILES
+    """
+
+    if not isinstance(smiles, str) or not smiles:
+        return None
+    try:
+        mol = Chem.MolFromSmiles(smiles)
+        if mol is None:
+            return None
+        Chem.SanitizeMol(mol)
+        # Remove salts / fragments
+        lfrag = rdMolStandardize.LargestFragmentChooser()
+        mol = lfrag.choose(mol)
+        # Reionize / neutralize
+        reionizer = rdMolStandardize.Reionizer()
+        mol = reionizer.reionize(mol)
+        uncharger = rdMolStandardize.Uncharger()
+        mol = uncharger.uncharge(mol)
+        Chem.SanitizeMol(mol)
+        return Chem.MolToSmiles(mol, canonical=True)
+    except Exception:
+        return None
+
+
+def standardize_dataset(smiles_list: Iterable[str]) -> StandardizationResult:
+    """Standardize an iterable of SMILES.
+
+    Returns standardized SMILES, their original indices, and list of failed
+    SMILES strings.
+    """
+
+    good: List[str] = []
+    valid_idx: List[int] = []
+    bad: List[str] = []
+    for idx, smi in enumerate(smiles_list):
+        std = standardize_smiles(smi)
+        if std is None:
+            bad.append(smi)
+        else:
+            good.append(std)
+            valid_idx.append(idx)
+    return StandardizationResult(smiles=good, valid_idx=valid_idx, failed=bad)

--- a/qsar/cli.py
+++ b/qsar/cli.py
@@ -1,0 +1,63 @@
+"""Command line interface for QSAR template."""
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+import joblib
+import numpy as np
+
+from .models.train import train as train_model
+from .chem.standardize import standardize_smiles
+from .chem.featurize import morgan_fingerprint, maccs_keys
+
+
+def cmd_fit(args: argparse.Namespace) -> None:
+    train_model(args.config)
+
+
+def cmd_predict(args: argparse.Namespace) -> None:
+    artifact = joblib.load(args.model)
+    model = artifact["model"]
+    feature_cfg = artifact.get("features", {})
+    icp_q = artifact.get("icp_quantile", 0.0)
+    df = csv.DictReader(open(args.input))
+    smiles = [standardize_smiles(row["smiles"]) or "" for row in df]
+    feats = []
+    if "ecfp4" in feature_cfg:
+        feats.append(morgan_fingerprint(smiles, radius=2, n_bits=feature_cfg.get("ecfp4", 2048)))
+    if "maccs" in feature_cfg:
+        feats.append(maccs_keys(smiles))
+    X = np.hstack(feats)
+    preds = model.predict(X)
+    with open(args.out, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["smiles", "prediction", "pi_low", "pi_high"])
+        for smi, p in zip(smiles, preds):
+            writer.writerow([smi, p, p - icp_q, p + icp_q])
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="qsar")
+    sub = parser.add_subparsers(dest="cmd")
+
+    p_fit = sub.add_parser("fit")
+    p_fit.add_argument("--config", required=True)
+    p_fit.set_defaults(func=cmd_fit)
+
+    p_pred = sub.add_parser("predict")
+    p_pred.add_argument("--model", required=True)
+    p_pred.add_argument("--input", required=True)
+    p_pred.add_argument("--out", required=True)
+    p_pred.set_defaults(func=cmd_predict)
+
+    args = parser.parse_args(argv)
+    if not hasattr(args, "func"):
+        parser.print_help()
+        return
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/qsar/dataio.py
+++ b/qsar/dataio.py
@@ -1,0 +1,49 @@
+"""Data loading and preprocessing utilities."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+import pandas as pd
+from rdkit import Chem
+
+from .chem.standardize import standardize_dataset
+from .chem.featurize import morgan_fingerprint, maccs_keys, mordred_descriptors
+from advisor.sessions import propose_smarts_filters
+
+
+def read_input(path: str | Path) -> pd.DataFrame:
+    path = Path(path)
+    if path.suffix.lower() == ".csv":
+        df = pd.read_csv(path)
+    elif path.suffix.lower() in {".parquet", ".pq"}:
+        df = pd.read_parquet(path)
+    else:
+        raise ValueError(f"Unsupported file format: {path.suffix}")
+    if "smiles" not in df.columns:
+        raise KeyError("Input must contain a 'smiles' column")
+    return df
+
+
+def standardize_frame(df: pd.DataFrame) -> pd.DataFrame:
+    result = standardize_dataset(df["smiles"].tolist())
+    df = df.iloc[result.valid_idx].reset_index(drop=True)
+    df["smiles"] = result.smiles
+    if result.failed:
+        fail_pct = len(result.failed) / (len(result.smiles) + len(result.failed))
+        examples = "\n".join(result.failed[:5])
+        Path("data_lint.md").write_text(
+            f"Failed to parse {fail_pct:.2%} SMILES\n\nExamples:\n{examples}\n"
+        )
+        if fail_pct > 0.02:
+            raise ValueError("Too many SMILES failed standardization")
+    # Query advisor for SMARTS filters suggestions
+    suggestions = propose_smarts_filters(df["smiles"].head(20).tolist())
+    if suggestions:
+        import yaml
+
+        filters_path = Path("filters/smarts.yaml")
+        filters_path.parent.mkdir(exist_ok=True)
+        with filters_path.open("w") as f:
+            yaml.safe_dump({"suggestions": suggestions}, f)
+    return df

--- a/qsar/explain/ecfp_bits.py
+++ b/qsar/explain/ecfp_bits.py
@@ -1,0 +1,22 @@
+"""Map ECFP bits back to atom environments."""
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+
+def bit_substructure(smiles: str, bit_id: int, radius: int = 2) -> Chem.Mol | None:
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        return None
+    info: Dict[int, Tuple[int, int]] = {}
+    AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=2048, bitInfo=info)
+    if bit_id not in info:
+        return None
+    atoms, rad = info[bit_id][0]
+    env = AllChem.FindAtomEnvironmentOfRadiusN(mol, rad, atoms)
+    amap = {}
+    submol = Chem.PathToSubmol(mol, env, atomMap=amap)
+    return submol

--- a/qsar/explain/shap_utils.py
+++ b/qsar/explain/shap_utils.py
@@ -1,0 +1,16 @@
+"""Utilities for SHAP explanations."""
+from __future__ import annotations
+
+import numpy as np
+
+try:
+    import shap
+except Exception:  # pragma: no cover
+    shap = None
+
+
+def compute_shap_values(model, X: np.ndarray) -> np.ndarray:
+    if shap is None:
+        raise ImportError("shap is required for explanations")
+    explainer = shap.TreeExplainer(model)
+    return explainer.shap_values(X)

--- a/qsar/models/classifiers.py
+++ b/qsar/models/classifiers.py
@@ -1,0 +1,34 @@
+"""Baseline classification models."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import accuracy_score, f1_score, roc_auc_score, average_precision_score
+
+try:
+    from lightgbm import LGBMClassifier
+except Exception:  # pragma: no cover
+    LGBMClassifier = None
+
+try:
+    from xgboost import XGBClassifier
+except Exception:  # pragma: no cover
+    XGBClassifier = None
+
+
+CLASSIFIERS: Dict[str, Any] = {
+    "random_forest": RandomForestClassifier,
+}
+if LGBMClassifier is not None:
+    CLASSIFIERS["lightgbm"] = LGBMClassifier
+if XGBClassifier is not None:
+    CLASSIFIERS["xgboost"] = XGBClassifier
+
+
+METRICS = {
+    "accuracy": accuracy_score,
+    "f1": f1_score,
+    "auroc": roc_auc_score,
+    "auprc": average_precision_score,
+}

--- a/qsar/models/gnn.py
+++ b/qsar/models/gnn.py
@@ -1,0 +1,21 @@
+"""Placeholder for optional GNN model."""
+from __future__ import annotations
+
+try:
+    import torch
+    from torch import nn
+    import torch_geometric
+except Exception:  # pragma: no cover
+    torch = None
+
+
+class SimpleGIN(nn.Module):  # type: ignore
+    def __init__(self):
+        super().__init__()
+        if torch is None:
+            raise ImportError("PyTorch Geometric not installed")
+        # Placeholder network
+        self.linear = nn.Linear(10, 1)
+
+    def forward(self, data):
+        return self.linear(data.x).mean(dim=1)

--- a/qsar/models/regressors.py
+++ b/qsar/models/regressors.py
@@ -1,0 +1,33 @@
+"""Baseline regression models."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+
+try:
+    from lightgbm import LGBMRegressor
+except Exception:  # pragma: no cover
+    LGBMRegressor = None
+
+try:
+    from xgboost import XGBRegressor
+except Exception:  # pragma: no cover
+    XGBRegressor = None
+
+
+REGRESSORS: Dict[str, Any] = {
+    "random_forest": RandomForestRegressor,
+}
+if LGBMRegressor is not None:
+    REGRESSORS["lightgbm"] = LGBMRegressor
+if XGBRegressor is not None:
+    REGRESSORS["xgboost"] = XGBRegressor
+
+
+METRICS = {
+    "rmse": lambda y, p: mean_squared_error(y, p, squared=False),
+    "mae": mean_absolute_error,
+    "r2": r2_score,
+}

--- a/qsar/models/train.py
+++ b/qsar/models/train.py
@@ -1,0 +1,91 @@
+"""Training pipeline."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Any
+
+import joblib
+import numpy as np
+import yaml
+
+from ..dataio import read_input, standardize_frame
+from ..chem.featurize import morgan_fingerprint, maccs_keys
+from ..chem.scaffold import scaffold_split, random_split
+from ..report.report import generate_report
+from .regressors import REGRESSORS, METRICS
+from ..tuning.optuna_search import tune
+
+
+def featurize(smiles: list[str], cfg: Dict[str, Any]) -> np.ndarray:
+    feats = []
+    if "ecfp4" in cfg:
+        feats.append(morgan_fingerprint(smiles, radius=2, n_bits=cfg.get("ecfp4", 2048)))
+    if "maccs" in cfg:
+        feats.append(maccs_keys(smiles))
+    if not feats:
+        raise ValueError("No features specified")
+    return np.hstack(feats)
+
+
+def train(config_path: str) -> Dict[str, Any]:
+    config = yaml.safe_load(Path(config_path).read_text())
+    df = read_input(config["data"])
+    df = standardize_frame(df)
+    smiles = df["smiles"].tolist()
+    target_col = config.get("target", "y")
+    y = df[target_col].to_numpy()
+    X = featurize(smiles, config.get("features", {}))
+
+    split_type = config.get("split", "scaffold")
+    test_size = config.get("test_size", 0.2)
+    seed = config.get("seed", 0)
+    if split_type == "scaffold":
+        split = scaffold_split(smiles, test_size=test_size, seed=seed)
+    else:
+        split = random_split(len(smiles), test_size=test_size, seed=seed)
+    X_train_full, y_train_full = X[split.train], y[split.train]
+    X_test, y_test = X[split.test], y[split.test]
+
+    # split calibration set
+    n_calib = max(1, int(0.2 * len(X_train_full)))
+    X_calib, y_calib = X_train_full[:n_calib], y_train_full[:n_calib]
+    X_train, y_train = X_train_full[n_calib:], y_train_full[n_calib:]
+
+    model_name = config.get("model", "lightgbm")
+    Model = REGRESSORS[model_name]
+
+    def objective(trial):
+        params = {}
+        if model_name == "lightgbm":
+            params["n_estimators"] = trial.suggest_int("n_estimators", 50, 200)
+            params["learning_rate"] = trial.suggest_float("learning_rate", 0.01, 0.3, log=True)
+        model = Model(random_state=seed, **params)
+        model.fit(X_train, y_train)
+        pred = model.predict(X_test)
+        from sklearn.metrics import mean_squared_error
+
+        return mean_squared_error(y_test, pred, squared=False)
+
+    n_trials = config.get("n_trials", 5)
+    study = tune(objective, n_trials=n_trials, seed=seed)
+    best_params = study.best_params
+    model = Model(random_state=seed, **best_params)
+    model.fit(X_train, y_train)
+    preds_calib = model.predict(X_calib)
+    resid = np.abs(y_calib - preds_calib)
+    quantile = float(np.quantile(resid, 1 - config.get("alpha", 0.1)))
+    model.fit(X_train_full, y_train_full)
+    preds = model.predict(X_test)
+
+    metrics = {name: fn(y_test, preds) for name, fn in METRICS.items()}
+    out_dir = config.get("output", "artifacts")
+    Path(out_dir).mkdir(exist_ok=True)
+    model_path = Path(out_dir) / "best_model.joblib"
+    joblib.dump({"model": model, "features": config.get("features", {}), "icp_quantile": quantile}, model_path)
+    run_dir = generate_report(out_dir, config, metrics)
+    card = Path(out_dir) / "model_card.md"
+    with card.open("w") as f:
+        f.write("# Model Card\n\n")
+        f.write(f"Model: {model_name}\n\n")
+        f.write(f"Training data: {config['data']}\n")
+    return {"model_path": str(model_path), "metrics": metrics}

--- a/qsar/report/report.py
+++ b/qsar/report/report.py
@@ -1,0 +1,23 @@
+"""Reporting utilities for QSAR runs."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Any
+
+import yaml
+
+
+def generate_report(output: str | Path, config: Dict[str, Any], metrics: Dict[str, float]) -> Path:
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    run_dir = Path(output) / f"run_{ts}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    summary = run_dir / "summary.md"
+    with summary.open("w") as f:
+        f.write("# QSAR Summary\n\n")
+        f.write("## Configuration\n")
+        yaml.safe_dump(config, f)
+        f.write("\n## Metrics\n")
+        for k, v in metrics.items():
+            f.write(f"- {k}: {v:.4f}\n")
+    return run_dir

--- a/qsar/serve/api.py
+++ b/qsar/serve/api.py
@@ -1,0 +1,57 @@
+"""FastAPI service for QSAR predictions."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List
+
+import joblib
+import numpy as np
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from ..chem.standardize import standardize_smiles
+from ..chem.featurize import morgan_fingerprint, maccs_keys
+
+app = FastAPI(title="QSAR Service")
+
+
+class PredictRequest(BaseModel):
+    smiles: List[str]
+
+
+class PredictRecord(BaseModel):
+    mean: float
+    pi_low: float
+    pi_high: float
+    in_domain: bool
+    notes: str | None = None
+
+
+MODEL_PATH = Path(os.getenv("QSAR_MODEL", "artifacts/best_model.joblib"))
+ARTIFACT = joblib.load(MODEL_PATH)
+MODEL = ARTIFACT["model"]
+FEATURE_CFG = ARTIFACT.get("features", {})
+ICP_Q = ARTIFACT.get("icp_quantile", 0.0)
+
+
+def _featurize(smiles: list[str]) -> np.ndarray:
+    feats = []
+    if "ecfp4" in FEATURE_CFG:
+        feats.append(morgan_fingerprint(smiles, radius=2, n_bits=FEATURE_CFG.get("ecfp4", 2048)))
+    if "maccs" in FEATURE_CFG:
+        feats.append(maccs_keys(smiles))
+    return np.hstack(feats)
+
+
+@app.post("/predict", response_model=List[PredictRecord])
+def predict(req: PredictRequest) -> List[PredictRecord]:
+    smi_std = [standardize_smiles(s) or "" for s in req.smiles]
+    X = _featurize(smi_std)
+    preds = MODEL.predict(X)
+    results = []
+    for p in preds:
+        low = p - ICP_Q
+        high = p + ICP_Q
+        results.append(PredictRecord(mean=float(p), pi_low=float(low), pi_high=float(high), in_domain=True))
+    return results

--- a/qsar/tuning/optuna_search.py
+++ b/qsar/tuning/optuna_search.py
@@ -1,0 +1,14 @@
+"""Optuna hyperparameter search utilities."""
+from __future__ import annotations
+
+from typing import Callable, Dict, Any
+
+import optuna
+
+
+def tune(objective: Callable[[optuna.Trial], float], n_trials: int, seed: int = 0) -> optuna.Study:
+    """Run an Optuna study with fixed seed."""
+    sampler = optuna.samplers.TPESampler(seed=seed)
+    study = optuna.create_study(direction="minimize", sampler=sampler)
+    study.optimize(objective, n_trials=n_trials)
+    return study

--- a/qsar/validity/conformal.py
+++ b/qsar/validity/conformal.py
@@ -1,0 +1,19 @@
+"""Inductive Conformal Prediction for regression."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+
+
+@dataclass
+class ICPRegressor:
+    alpha: float = 0.1
+
+    def fit(self, y_calib: np.ndarray, y_pred_calib: np.ndarray) -> None:
+        self.residuals_ = np.abs(y_calib - y_pred_calib)
+        self.quantile_ = np.quantile(self.residuals_, 1 - self.alpha)
+
+    def predict(self, y_pred: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        lower = y_pred - self.quantile_
+        upper = y_pred + self.quantile_
+        return lower, upper

--- a/qsar/validity/domain.py
+++ b/qsar/validity/domain.py
@@ -1,0 +1,32 @@
+"""Domain of applicability via Tanimoto kNN."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import numpy as np
+from rdkit import Chem, DataStructs
+
+
+@dataclass
+class KNNDomain:
+    k: int = 5
+    percentile: float = 95.0
+
+    def fit(self, train_fps: List[Chem.rdchem.Mol]) -> None:
+        self.train_fps = train_fps
+        dists = []
+        for fp in train_fps:
+            sims = DataStructs.BulkTanimotoSimilarity(fp, train_fps)
+            sims = sorted(sims, reverse=True)[1 : self.k + 1]
+            dists.append(1 - np.mean(sims))
+        self.threshold_ = np.percentile(dists, self.percentile)
+
+    def predict(self, fps: List[Chem.rdchem.Mol]) -> np.ndarray:
+        flags = []
+        for fp in fps:
+            sims = DataStructs.BulkTanimotoSimilarity(fp, self.train_fps)
+            sims = sorted(sims, reverse=True)[: self.k]
+            dist = 1 - np.mean(sims)
+            flags.append(dist <= self.threshold_)
+        return np.asarray(flags)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+rdkit-pypi
+pandas
+numpy
+scikit-learn
+lightgbm
+xgboost
+optuna
+mordred
+shap
+fastapi
+uvicorn
+joblib
+pydantic
+pyyaml
+requests

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,12 @@
+import numpy as np
+from qsar.chem.featurize import morgan_fingerprint, maccs_keys
+
+
+def test_feature_shapes():
+    smiles = ["CCO", "c1ccccc1"]
+    X1 = morgan_fingerprint(smiles)
+    X2 = maccs_keys(smiles)
+    assert X1.shape == (2, 2048)
+    assert X2.shape == (2, 166)
+    assert X1.dtype == int
+    assert X2.dtype == int

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,22 @@
+import yaml
+from pathlib import Path
+
+from qsar.models.train import train
+
+
+def test_metric_reproducibility(tmp_path):
+    cfg = {
+        "data": str(Path("data/esol.csv")),
+        "target": "y",
+        "model": "lightgbm",
+        "features": {"ecfp4": 2048},
+        "split": "scaffold",
+        "seed": 1,
+        "n_trials": 1,
+        "output": str(tmp_path),
+    }
+    cfg_path = tmp_path / "cfg.yaml"
+    yaml.safe_dump(cfg, cfg_path.open("w"))
+    res1 = train(str(cfg_path))
+    res2 = train(str(cfg_path))
+    assert res1["metrics"]["rmse"] == res2["metrics"]["rmse"]

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -1,0 +1,18 @@
+from qsar.chem.scaffold import scaffold_split, bemis_murcko_scaffold
+
+
+def test_scaffold_split_no_leakage():
+    smiles = [
+        "CCO",
+        "CCN",
+        "CCC",
+        "c1ccccc1",
+        "c1ccncc1",
+        "CC(=O)O",
+        "CCOC(=O)C",
+        "CCSC",
+    ]
+    split = scaffold_split(smiles, test_size=0.25, seed=0)
+    sc_train = {bemis_murcko_scaffold(smiles[i]) for i in split.train}
+    sc_test = {bemis_murcko_scaffold(smiles[i]) for i in split.test}
+    assert sc_train.isdisjoint(sc_test)


### PR DESCRIPTION
## Summary
- lay groundwork for local-first QSAR workflow with RDKit standardization, featurization and scaffold splits
- add baseline model training with Optuna, conformal intervals, FastAPI service and CLI
- integrate simple Ollama-based advisor hooks and include ESOL demo config

## Testing
- `pytest -q` *(fails: No module named 'numpy', 'yaml', 'qsar')*


------
https://chatgpt.com/codex/tasks/task_e_68951cc6cb288320a935f48ed0be193f